### PR TITLE
Update to Pandoc 3 and synchronize versions between development and deployment environments

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,12 +21,10 @@ jobs:
         with:
           submodules: recursive
 
-      # Installing pandoc is done this way instead of with the package manager because the version
-      # on apt is just too old
       - name: Install pandoc
-        run: |
-          wget https://github.com/jgm/pandoc/releases/download/3.1.12.3/pandoc-3.1.12.3-1-amd64.deb
-          sudo dpkg -i pandoc-3.1.12.3-1-amd64.deb
+        uses: pandoc/actions/setup@{main}
+        with:
+          version: 3.1.12.3
 
       - name: Convert all markdown to HTML
         run: bash ${{ github.workspace }}/build/build_all.sh -v

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -28,9 +28,6 @@ jobs:
           wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-amd64.deb
           sudo dpkg -i pandoc-2.19.2-1-amd64.deb
 
-      - name: Install premailer
-        run: pip3 install --user premailer
-
       - name: Convert all markdown to HTML
         run: bash ${{ github.workspace }}/build/build_all.sh -v
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -25,8 +25,8 @@ jobs:
       # on apt is just too old
       - name: Install pandoc
         run: |
-          wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-amd64.deb
-          sudo dpkg -i pandoc-2.19.2-1-amd64.deb
+          wget https://github.com/jgm/pandoc/releases/download/3.1.12.3/pandoc-3.1.12.3-1-amd64.deb
+          sudo dpkg -i pandoc-3.1.12.3-1-amd64.deb
 
       - name: Convert all markdown to HTML
         run: bash ${{ github.workspace }}/build/build_all.sh -v

--- a/build/defaults.yaml
+++ b/build/defaults.yaml
@@ -9,4 +9,7 @@ resource-path:
 table-of-contents: true
 variables:
   default-monofont-pdf: "Fira Code"
+  fontsize: "20px"
+  linestretch: "1.5"
+  mainfont-html: "Helvetica Neue, Helvetica, Arial, sans-serif"
   toc-title: "Contents"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,15 @@
 ARG SERVER_PORT
 
-FROM alpine:3
+FROM ubuntu:22.04
 
-RUN apk add --no-cache \
-	bash \
+RUN apt-get update && apt-get install -y \
 	coreutils \
+	curl \
 	findutils \
-	pandoc \
 	perl \
 	python3
+
+RUN curl --output-dir /tmp --remote-name --location "https://github.com/jgm/pandoc/releases/download/3.1.12.3/pandoc-3.1.12.3-1-amd64.deb" && dpkg -i /tmp/pandoc-3.1.12.3-1-amd64.deb
 
 WORKDIR /mnt/project
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     cs-materials:
         env_file:


### PR DESCRIPTION
This works on completing #51. All templates, the GitHub Actions workflow, and Docker container are now all updated to be in line with the newest version of Pandoc as of the time of writing (3.1.12.3).