### PR TITLE
GitHub Actions: Fix Pandoc installation

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: recursive
 
       - name: Install pandoc
-        uses: pandoc/actions/setup@{main}
+        uses: pandoc/actions/setup@v1
         with:
           version: 3.1.12.3
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,10 +21,12 @@ jobs:
         with:
           submodules: recursive
 
+      # Installing pandoc is done this way instead of with the package manager because the version
+      # on apt is just too old
       - name: Install pandoc
-        uses: pandoc/actions/setup@v1
-        with:
-          version: 3.1.12.3
+        run: |
+          wget https://github.com/jgm/pandoc/releases/download/3.1.12.3/pandoc-3.1.12.3-1-amd64.deb
+          sudo dpkg -i pandoc-3.1.12.3-1-amd64.deb
 
       - name: Convert all markdown to HTML
         run: bash ${{ github.workspace }}/build/build_all.sh -v


### PR DESCRIPTION
For reasons beyond comprehension at this time, the GitHub Action provided by the Pandoc project does not work successfully. We will continue to use the method that has been proven for some time.