### PR TITLE
github-actions: Update upload-artifact to v4

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,7 +33,7 @@ jobs:
 
       # The build output is uploaded to an artifact so it can then be downloaded by the deploy job
       - name: Upload files
-        uses: actions/upload-artifact@v3.0.0
+        uses: actions/upload-artifact@v4
         with:
           # Artifact name
           name: output


### PR DESCRIPTION
v3 is deprecated and will be closing down on January 30, 2025.

See for more details: https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/